### PR TITLE
Pass env vars

### DIFF
--- a/tests/test_binderbot.py
+++ b/tests/test_binderbot.py
@@ -14,45 +14,28 @@ from binderbot import cli
 
 @pytest.fixture()
 def example_nb_data():
-    nbdata = {'cells': [{'cell_type': 'markdown',
-               'metadata': {},
-               'source': '# Test Pangeo Gallery'},
-              {'cell_type': 'code',
-               'execution_count': 1,
-               'metadata': {},
-               'outputs': [{'name': 'stdout',
-                 'output_type': 'stream',
-                 'text': "Today's date: 2020-03-12\n"}],
-               'source': 'from datetime import date\ntoday = date.today()\nprint("Today\'s date:", today)'},
-              {'cell_type': 'code',
-               'execution_count': 2,
-               'metadata': {},
-               'outputs': [{'name': 'stdout',
-                 'output_type': 'stream',
-                 'text': 'Ryans-MacBook-Pro.local\n'}],
-               'source': 'import socket\nprint(socket.gethostname())'},
-              {'cell_type': 'code',
-               'execution_count': 0,
-               'metadata': {},
-               'outputs': [],
-               'source': 'import time\ntime.sleep(2)'},
-              {'cell_type': 'code',
-               'execution_count': None,
-               'metadata': {},
-               'outputs': [],
-               'source': ''}],
-             'metadata': {'kernelspec': {'display_name': 'Python 3',
-               'language': 'python',
-               'name': 'python3'},
-              'language_info': {'codemirror_mode': {'name': 'ipython', 'version': 3},
-               'file_extension': '.py',
-               'mimetype': 'text/x-python',
-               'name': 'python',
-               'nbconvert_exporter': 'python',
-               'pygments_lexer': 'ipython3',
-               'version': '3.6.7'}},
-             'nbformat': 4,
-             'nbformat_minor': 4}
+    nbdata = {'cells': [{'cell_type': 'code',
+                       'execution_count': None,
+                       'metadata': {},
+                       'outputs': [],
+                       'source': 'import socket\nprint(socket.gethostname())'},
+                      {'cell_type': 'code',
+                       'execution_count': None,
+                       'metadata': {},
+                       'outputs': [],
+                       'source': 'import os\nprint(os.environ["MY_VAR"])'}],
+                     'metadata': {'kernelspec': {'display_name': 'Python 3',
+                       'language': 'python',
+                       'name': 'python3'},
+                      'language_info': {'codemirror_mode': {'name': 'ipython', 'version': 3},
+                       'file_extension': '.py',
+                       'mimetype': 'text/x-python',
+                       'name': 'python',
+                       'nbconvert_exporter': 'python',
+                       'pygments_lexer': 'ipython3',
+                       'version': '3.8.1'}},
+                     'nbformat': 4,
+                     'nbformat_minor': 4}
     return nbformat.from_dict(nbdata)
 
     return tmpdir
@@ -66,20 +49,23 @@ def test_cli_upload_execute_download(tmp_path, example_nb_data):
     with open(fname, 'w', encoding='utf-8') as f:
         nbformat.write(example_nb_data, f)
 
-    runner = CliRunner()
+    env = {"MY_VAR": "SECRET"}
+    runner = CliRunner(env=env)
     args = ["--binder-url", "http://mybinder.org",
             "--repo", "binder-examples/requirements",
             "--ref", "master", "--nb-timeout", "10",
+            "--pass-env-var",  "MY_VAR",
             fname]
     result = runner.invoke(cli.main, args)
     assert result.exit_code == 0, result.output
-    # assert 'binderbot.cli.main' in result.output
 
     with open(fname) as f:
         nb = nbformat.read(f, as_version=4)
 
-    hostname = nb['cells'][2]['outputs'][0]['text']
+    hostname = nb['cells'][0]['outputs'][0]['text']
     assert hostname.startswith('jupyter-binder-')
+    remote_env_var_value = nb['cells'][1]['outputs'][0]['text']
+    assert remote_env_var_value == env['MY_VAR'].rstrip()
 
     # help_result = runner.invoke(cli.main, ['--help'])
     # assert help_result.exit_code == 0

--- a/tests/test_binderbot.py
+++ b/tests/test_binderbot.py
@@ -65,7 +65,7 @@ def test_cli_upload_execute_download(tmp_path, example_nb_data):
     hostname = nb['cells'][0]['outputs'][0]['text']
     assert hostname.startswith('jupyter-binder-')
     remote_env_var_value = nb['cells'][1]['outputs'][0]['text']
-    assert remote_env_var_value == env['MY_VAR'].rstrip()
+    assert remote_env_var_value.rstrip() == env['MY_VAR']
 
     # help_result = runner.invoke(cli.main, ['--help'])
     # assert help_result.exit_code == 0


### PR DESCRIPTION
This adds the new option `--pass-env-var`, which will pass through environment variables from the local to remote environment.

Is this secure enough to put secrets tokens in?

Also fixes #12.