### PR TITLE
Shut down binder instance when we are done with it

### DIFF
--- a/binderbot/binderbot.py
+++ b/binderbot/binderbot.py
@@ -94,10 +94,22 @@ class BinderUser:
         self.state = BinderUser.States.BINDER_STARTED
 
     async def shutdown_binder(self):
-        # TODO: figure out how to shut down the binder using the API
-        # can we use the jupyterhub API:
-        # https://jupyterhub.readthedocs.io/en/stable/reference/rest.html#enabling-users-to-spawn-multiple-named-servers-via-the-api
-        pass
+        """
+        Shut down running binder instance.
+        """
+        if self.state != BinderUser.States.KERNEL_STARTED:
+            await self.start_kernel()
+        # Ideally, we will talk to the hub API to shut this down
+        # However, the token we get is just a notebook auth token, *not* a hub auth otken
+        # So we can't make requests to the hub API.
+        # FIXME: Provide hub auth tokens from binderhub API
+        await self.run_code("""
+        import os
+        import signal
+        # FIXME: Wait a bit, and send SIGKILL otherwise
+        os.kill(1, signal.SIGTERM)
+        """)
+        self.state = BinderUser.States.CLEAR
 
     async def start_kernel(self):
         assert self.state == BinderUser.States.BINDER_STARTED

--- a/binderbot/cli.py
+++ b/binderbot/cli.py
@@ -86,9 +86,8 @@ async def main(binder_url, repo, ref, output_dir, nb_timeout,
         if len(errors) > 0:
             raise RuntimeError(str(errors))
 
-        # TODO: shut down binder
-        # await jovyan.shutdown_binder()
-        # can we do this with a context manager so that it shuts down in case of errors?
+        # TODO: can we do this with a context manager so that it shuts down in case of errors?
+        await jovyan.shutdown_binder()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We should shut down binder instance when we are done, to
conserve resources and prevent ourselves from hitting usage
limits. Ideally, the token received from BinderHub can
be used to call the JupyterHub API to shut it down. However,
the token we get from BinderHub isn't a valid JupyterHub
token - just a valid Jupyter Notebook token. All JupyterHub
tokens are valid Jupyter Notebook tokens, but not all
Jupyter Notebook tokens are valid JupyterHub tokens! This
was a decision we made early on in the process so users
didn't need to have 'jupyterhub' installed inside their
containers.

We instead kill pid 1, which stops the container. JupyterHub
should garbage collect this shortly after. This is very
hacky, but works

Fix #3