### PR TITLE
Add separate CI for docs & linting checks

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v2
@@ -27,7 +27,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .
-    - name: Test with pytest
+    - name: Build docs
       run: |
         pip install -r requirements_dev.txt
-        pytest tests/
+        cd docs
+        make html

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v2
@@ -23,11 +23,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install package
+    - name: Lint with flake8
       run: |
-        python -m pip install --upgrade pip
-        pip install .
-    - name: Test with pytest
-      run: |
-        pip install -r requirements_dev.txt
-        pytest tests/
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ A simple CLI to interact with binder.
 Example Usage
 -------------
 
-.. code-block::
+.. code:: python
 
    $ python -m binderbot.cli --help
    Usage: cli.py [OPTIONS] [FILENAMES]...

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,6 @@ Welcome to Binderbot's documentation!
    readme
    installation
    usage
-   modules
    contributing
    history
 


### PR DESCRIPTION
Keeping this separate from unit tests makes it easier
for people to see what failed.

Linting *only* fails on syntax errors, nothing more