### PR TITLE
Refactor code to be more testable

### DIFF
--- a/binderbot/__init__.py
+++ b/binderbot/__init__.py
@@ -7,3 +7,7 @@ __version__ = '0.1.0'
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+
+class OperationError(Exception):
+    pass

--- a/binderbot/binderbot.py
+++ b/binderbot/binderbot.py
@@ -20,12 +20,6 @@ logger = structlog.get_logger()
 
 
 class BinderUser:
-    class States(Enum):
-        CLEAR = 1
-        # LOGGED_IN = 2
-        BINDER_STARTED = 3
-        KERNEL_STARTED = 4
-
     async def __aenter__(self):
         self.session = aiohttp.ClientSession(headers={'User-Agent': 'BinderBot-cli v0.1'})
         return self
@@ -41,7 +35,6 @@ class BinderUser:
         self.binder_url = URL(binder_url)
         self.repo = repo
         self.ref = ref
-        self.state = BinderUser.States.CLEAR
         self.log = logger.bind()
 
     async def start_binder(self, timeout=3000, spawn_refresh_time=20):
@@ -76,9 +69,6 @@ class BinderUser:
                     raise OperationError()
                 self.log.msg(f'Binder: Waiting on event stream (phase: {phase})', action='binder-start', phase='event-stream')
 
-
-        # todo: double check phase is really always "ready" at this point
-        self.state = BinderUser.States.BINDER_STARTED
 
     async def shutdown_binder(self):
         """

--- a/binderbot/binderbot.py
+++ b/binderbot/binderbot.py
@@ -6,24 +6,15 @@ https://github.com/yuvipanda/hubtraf/blob/master/hubtraf/user.py
 
 from enum import Enum, auto
 import aiohttp
-import socket
-import uuid
-import random
 from yarl import URL
-import asyncio
-import async_timeout
 import structlog
 import time
 import json
-import textwrap
-import re
-from contextlib import asynccontextmanager
 
-import nbformat
-from nbconvert.preprocessors import ClearOutputPreprocessor
 
 from binderbot import OperationError
 from .kernel import Kernel
+from .notebookclient import NotebookClient
 
 logger = structlog.get_logger()
 
@@ -107,77 +98,3 @@ class BinderUser:
             # FIXME: Wait a bit, and send SIGKILL otherwise
             os.kill(1, signal.SIGTERM)
             """)
-
-
-class NotebookClient:
-    """
-    Client for doing operations against a notebook server
-    """
-    def __init__(self, session: aiohttp.ClientSession, url: URL, token: str, log: structlog.BoundLogger):
-        # FIXME: If we get this from BinderBot, will it close properly?
-        self.session = session
-        self.url = url
-        self.token = token
-        self.log = log
-
-        self.auth_headers = {
-            'Authorization': f'token {self.token}'
-        }
-
-    @asynccontextmanager
-    async def start_kernel(self, cleanup=True):
-        self.log.msg('Kernel: Starting', action='kernel-start', phase='start')
-        start_time = time.monotonic()
-
-        try:
-            resp = await self.session.post(self.url / 'api/kernels', headers=self.auth_headers)
-        except Exception as e:
-            self.log.msg('Kernel: Start failed {}'.format(str(e)), action='kernel-start', phase='failed', duration=time.monotonic() - start_time)
-            raise OperationError()
-
-        if resp.status != 201:
-            self.log.msg('Kernel: Start failed', action='kernel-start', phase='failed')
-            raise OperationError()
-        kernel_id = (await resp.json())['id']
-        self.log.msg('Kernel: Started', action='kernel-start', phase='complete')
-        k = Kernel(self, kernel_id)
-        try:
-            yield k
-        finally:
-            if cleanup:
-                await k.stop_kernel()
-
-    # https://github.com/jupyter/jupyter/wiki/Jupyter-Notebook-Server-API#notebook-and-file-contents-api
-    async def get_contents(self, path):
-        resp = await self.session.get(self.url / 'api/contents' / path, headers=self.auth_headers)
-        resp_json = await resp.json()
-        return resp_json['content']
-
-    async def put_contents(self, path, nb_data):
-        data = {'content': nb_data, "type": "notebook"}
-        resp = await self.session.put(self.url / 'api/contents' / path,
-                                      json=data, headers=self.auth_headers)
-        resp.raise_for_status()
-
-
-    async def list_notebooks(self):
-        code = """
-        import os, fnmatch, json
-        notebooks = [f for f in os.listdir() if fnmatch.fnmatch(f, '*.ipynb')]
-        print(json.dumps(notebooks))
-        """
-        stdout, stderr = await self.run_code(code)
-        return json.loads(stdout)
-
-    async def upload_local_notebook(self, notebook_filename):
-        nb = open_nb_and_strip_output(notebook_filename)
-        # probably want to use basename instead
-        await self.put_contents(notebook_filename, nb)
-
-
-def open_nb_and_strip_output(fname):
-    cop = ClearOutputPreprocessor()
-    with open(fname) as f:
-        nb = nbformat.read(f, as_version=4)
-    cop.preprocess(nb, dict())
-    return nb

--- a/binderbot/binderbot.py
+++ b/binderbot/binderbot.py
@@ -94,10 +94,22 @@ class BinderUser:
         self.state = BinderUser.States.BINDER_STARTED
 
     async def shutdown_binder(self):
-        # TODO: figure out how to shut down the binder using the API
-        # can we use the jupyterhub API:
-        # https://jupyterhub.readthedocs.io/en/stable/reference/rest.html#enabling-users-to-spawn-multiple-named-servers-via-the-api
-        pass
+        """
+        Shut down running binder instance.
+        """
+        if self.state != BinderUser.States.KERNEL_STARTED:
+            await self.start_kernel()
+        # Ideally, we will talk to the hub API to shut this down
+        # However, the token we get is just a notebook auth token, *not* a hub auth otken
+        # So we can't make requests to the hub API.
+        # FIXME: Provide hub auth tokens from binderhub API
+        await self.run_code("""
+        import os
+        import signal
+        # FIXME: Wait a bit, and send SIGKILL otherwise
+        os.kill(1, signal.SIGTERM)
+        """)
+        self.state = BinderUser.States.CLEAR
 
     async def start_kernel(self):
         assert self.state == BinderUser.States.BINDER_STARTED

--- a/binderbot/binderbot.py
+++ b/binderbot/binderbot.py
@@ -17,19 +17,15 @@ import time
 import json
 import textwrap
 import re
+from contextlib import asynccontextmanager
 
 import nbformat
 from nbconvert.preprocessors import ClearOutputPreprocessor
 
+from binderbot import OperationError
+from .kernel import Kernel
+
 logger = structlog.get_logger()
-
-# https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
-def _ansi_escape(text):
-    return re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])').sub('', text)
-
-
-class OperationError(Exception):
-    pass
 
 
 class BinderUser:
@@ -102,13 +98,13 @@ class BinderUser:
         # So we can't make requests to the hub API.
         # FIXME: Provide hub auth tokens from binderhub API
         nbclient = NotebookClient(self.session, self.notebook_url, self.token, self.log)
-        await nbclient.start_kernel()
-        await nbclient.run_code("""
-        import os
-        import signal
-        # FIXME: Wait a bit, and send SIGKILL otherwise
-        os.kill(1, signal.SIGTERM)
-        """)
+        async with nbclient.start_kernel() as kernel:
+            await kernel.run_code("""
+            import os
+            import signal
+            # FIXME: Wait a bit, and send SIGKILL otherwise
+            os.kill(1, signal.SIGTERM)
+            """)
 
 
 class NotebookClient:
@@ -126,6 +122,7 @@ class NotebookClient:
             'Authorization': f'token {self.token}'
         }
 
+    @asynccontextmanager
     async def start_kernel(self):
         self.log.msg('Kernel: Starting', action='kernel-start', phase='start')
         start_time = time.monotonic()
@@ -139,25 +136,13 @@ class NotebookClient:
         if resp.status != 201:
             self.log.msg('Kernel: Start failed', action='kernel-start', phase='failed')
             raise OperationError()
-        self.kernel_id = (await resp.json())['id']
+        kernel_id = (await resp.json())['id']
         self.log.msg('Kernel: Started', action='kernel-start', phase='complete')
-        self.state = BinderUser.States.KERNEL_STARTED
-
-
-    async def stop_kernel(self):
-        self.log.msg('Kernel: Stopping', action='kernel-stop', phase='start')
-        start_time = time.monotonic()
+        k = Kernel(self, kernel_id)
         try:
-            resp = await self.session.delete(self.url / 'api/kernels' / self.kernel_id, headers=self.auth_headers)
-        except Exception as e:
-            self.log.msg('Kernel:Failed Stopped {}'.format(str(e)), action='kernel-stop', phase='failed')
-            raise OperationError()
-
-        if resp.status != 204:
-            self.log.msg('Kernel:Failed Stopped {}'.format(str(resp)), action='kernel-stop', phase='failed')
-            raise OperationError()
-
-        self.log.msg('Kernel: Stopped', action='kernel-stop', phase='complete')
+            yield k
+        finally:
+            await k.stop_kernel()
 
     # https://github.com/jupyter/jupyter/wiki/Jupyter-Notebook-Server-API#notebook-and-file-contents-api
     async def get_contents(self, path):
@@ -171,108 +156,6 @@ class NotebookClient:
                                       json=data, headers=self.auth_headers)
         resp.raise_for_status()
 
-    def request_execute_code(self, msg_id, code):
-        return {
-            "header": {
-                "msg_id": msg_id,
-                "username": "jovyan",
-                "msg_type": "execute_request",
-                "version": "5.2"
-            },
-            "metadata": {},
-            "content": {
-                "code": textwrap.dedent(code),
-                "silent": False,
-                "store_history": True,
-                "user_expressions": {},
-                "allow_stdin": True,
-                "stop_on_error": True
-            },
-            "buffers": [],
-            "parent_header": {},
-            "channel": "shell"
-        }
-
-
-    async def run_code(self, code):
-        """Run code and return stdout, stderr."""
-        channel_url = self.url / 'api/kernels' / self.kernel_id / 'channels'
-        self.log.msg('WS: Connecting', action='kernel-connect', phase='start')
-        is_connected = False
-        try:
-            async with self.session.ws_connect(channel_url) as ws:
-                is_connected = True
-                self.log.msg('WS: Connected', action='kernel-connect', phase='complete')
-                start_time = time.monotonic()
-                self.log.msg('Code Execute: Started', action='code-execute', phase='start')
-                exec_start_time = time.monotonic()
-                msg_id = str(uuid.uuid4())
-                await ws.send_json(self.request_execute_code(msg_id, code))
-
-                stdout = ''
-                stderr = ''
-
-                async for msg_text in ws:
-                    if msg_text.type != aiohttp.WSMsgType.TEXT:
-                        self.log.msg(
-                            'WS: Unexpected message type',
-                            action='code-execute', phase='failure',
-                            message_type=msg_text.type, message=str(msg_text),
-                            duration=time.monotonic() - exec_start_time
-                        )
-                        raise OperationError()
-
-                    msg = msg_text.json()
-
-                    if 'parent_header' in msg and msg['parent_header'].get('msg_id') == msg_id:
-                        # These are responses to our request
-                        self.log.msg(f'Code Execute: Receive response', action='code-execute', phase='receive-stream',
-                                     channel=msg['channel'], msg_type=msg['msg_type'])
-                        if msg['channel'] == 'shell':
-                            if msg['msg_type'] == 'execute_reply':
-                                status = msg['content']['status']
-                                if status == 'ok':
-                                    self.log.msg('Code Execute: Status OK', action='code-execute', phase='success')
-                                    break
-                                else:
-                                    self.log.msg('Code Execute: Status {status}', action='code-execute', phase='error')
-                                    raise OperationError()
-                        if msg['channel'] == 'iopub':
-                            response = None
-                            msg_type = msg.get('msg_type')
-                            # don't really know what this is doing
-                            #if msg_type == 'execute_result':
-                            #    response = msg['content']['data']['text/plain']
-                            if msg_type == 'error':
-                                traceback = _ansi_escape('\n'.join(msg['content']['traceback']))
-                                self.log.msg('Code Execute: Error', action='code-execute',
-                                             phase='error',
-                                             traceback=traceback)
-                                raise OperationError()
-                            elif msg_type == 'stream':
-                                response = msg['content']['text']
-                                name =  msg['content']['name']
-                                if name == 'stdout':
-                                    stdout += response
-                                elif name == 'stderr':
-                                    stderr += response
-                                #print(response)
-                self.log.msg(
-                    'Code Execute: complete',
-                    action='code-execute', phase='complete',
-                    duration=time.monotonic() - exec_start_time)
-
-                return stdout, stderr
-
-        except Exception as e:
-            if type(e) is OperationError:
-                raise
-            if is_connected:
-                self.log.msg('Code Execute: Failed {}'.format(str(e)), action='code-execute', phase='failure')
-            else:
-                self.log.msg('WS: Failed {}'.format(str(e)), action='kernel-connect', phase='failure')
-            raise OperationError()
-
 
     async def list_notebooks(self):
         code = """
@@ -282,28 +165,6 @@ class NotebookClient:
         """
         stdout, stderr = await self.run_code(code)
         return json.loads(stdout)
-
-    async def execute_notebook(self, notebook_filename, timeout=600,
-                               env_vars={}):
-        env_var_str = str(env_vars)
-        # https://nbconvert.readthedocs.io/en/latest/execute_api.html
-        code = f"""
-        import os
-        import nbformat
-        os.environ.update({env_var_str})
-        from nbconvert.preprocessors import ExecutePreprocessor
-        ep = ExecutePreprocessor(timeout={timeout})
-        print("Processing {notebook_filename}")
-        with open("{notebook_filename}") as f:
-            nb = nbformat.read(f, as_version=4)
-        ep.preprocess(nb, dict())
-        print("OK")
-        print("Saving {notebook_filename}")
-        with open("{notebook_filename}", 'w', encoding='utf-8') as f:
-            nbformat.write(nb, f)
-        print("OK")
-        """
-        return await self.run_code(code)
 
     async def upload_local_notebook(self, notebook_filename):
         nb = open_nb_and_strip_output(notebook_filename)

--- a/binderbot/cli.py
+++ b/binderbot/cli.py
@@ -86,9 +86,8 @@ async def main(binder_url, repo, ref, output_dir, nb_timeout,
         if len(errors) > 0:
             raise RuntimeError(str(errors))
 
-        # TODO: shut down binder
-        # await jovyan.shutdown_binder()
-        # can we do this with a context manager so that it shuts down in case of errors?
+        # TODO: can we do this with a context manager so that it shuts down in case of errors?
+        await jovyan.shutdown_binder()
 
 
 if __name__ == "__main__":

--- a/binderbot/cli.py
+++ b/binderbot/cli.py
@@ -7,7 +7,7 @@ import sys
 import click
 import nbformat
 
-from .binderbot import BinderUser
+from .binderbot import BinderUser, NotebookClient
 
 # https://github.com/pallets/click/issues/85#issuecomment-43378930
 def coro(f):
@@ -56,7 +56,8 @@ async def main(binder_url, repo, ref, output_dir, nb_timeout,
     # inputs look good, start up binder
     async with BinderUser(binder_url, repo, ref) as jovyan:
         await jovyan.start_binder(timeout=binder_start_timeout)
-        await jovyan.start_kernel()
+        nb = NotebookClient(jovyan.session, jovyan.notebook_url, jovyan.token, jovyan.log)
+        await nb.start_kernel()
         click.echo(f"✅ Binder and kernel started successfully.")
         # could think about asyncifying this whole loop
         # for now, we run one notebook at a time to avoid overloading the binder
@@ -64,14 +65,14 @@ async def main(binder_url, repo, ref, output_dir, nb_timeout,
         for fname in filenames:
             try:
                 click.echo(f"⌛️ Uploading {fname}...", nl=False)
-                await jovyan.upload_local_notebook(fname)
+                await nb.upload_local_notebook(fname)
                 click.echo("✅")
                 click.echo(f"⌛️ Executing {fname}...", nl=False)
-                await jovyan.execute_notebook(fname, timeout=nb_timeout,
+                await nb.execute_notebook(fname, timeout=nb_timeout,
                                               env_vars=extra_env_vars)
                 click.echo("✅")
                 click.echo(f"⌛️ Downloading and saving {fname}...", nl=False)
-                nb_data = await jovyan.get_contents(fname)
+                nb_data = await nb.get_contents(fname)
                 nb = nbformat.from_dict(nb_data)
                 output_fname = os.path.join(output_dir, fname) if output_dir else fname
                 with open(output_fname, 'w', encoding='utf-8') as f:
@@ -81,7 +82,7 @@ async def main(binder_url, repo, ref, output_dir, nb_timeout,
                 errors[fname] = e
                 click.echo(f'❌ error running {fname}: {e}')
 
-        await jovyan.stop_kernel()
+        await nb.stop_kernel()
 
         if len(errors) > 0:
             raise RuntimeError(str(errors))

--- a/binderbot/cli.py
+++ b/binderbot/cli.py
@@ -57,32 +57,30 @@ async def main(binder_url, repo, ref, output_dir, nb_timeout,
     async with BinderUser(binder_url, repo, ref) as jovyan:
         await jovyan.start_binder(timeout=binder_start_timeout)
         nb = NotebookClient(jovyan.session, jovyan.notebook_url, jovyan.token, jovyan.log)
-        await nb.start_kernel()
-        click.echo(f"✅ Binder and kernel started successfully.")
-        # could think about asyncifying this whole loop
-        # for now, we run one notebook at a time to avoid overloading the binder
-        errors = {}
-        for fname in filenames:
-            try:
-                click.echo(f"⌛️ Uploading {fname}...", nl=False)
-                await nb.upload_local_notebook(fname)
-                click.echo("✅")
-                click.echo(f"⌛️ Executing {fname}...", nl=False)
-                await nb.execute_notebook(fname, timeout=nb_timeout,
-                                              env_vars=extra_env_vars)
-                click.echo("✅")
-                click.echo(f"⌛️ Downloading and saving {fname}...", nl=False)
-                nb_data = await nb.get_contents(fname)
-                nb = nbformat.from_dict(nb_data)
-                output_fname = os.path.join(output_dir, fname) if output_dir else fname
-                with open(output_fname, 'w', encoding='utf-8') as f:
-                    nbformat.write(nb, f)
-                click.echo("✅")
-            except Exception as e:
-                errors[fname] = e
-                click.echo(f'❌ error running {fname}: {e}')
-
-        await nb.stop_kernel()
+        async with nb.start_kernel() as kernel:
+            click.echo(f"✅ Binder and kernel started successfully.")
+            # could think about asyncifying this whole loop
+            # for now, we run one notebook at a time to avoid overloading the binder
+            errors = {}
+            for fname in filenames:
+                try:
+                    click.echo(f"⌛️ Uploading {fname}...", nl=False)
+                    await nb.upload_local_notebook(fname)
+                    click.echo("✅")
+                    click.echo(f"⌛️ Executing {fname}...", nl=False)
+                    await kernel.execute_notebook(fname, timeout=nb_timeout,
+                                                env_vars=extra_env_vars)
+                    click.echo("✅")
+                    click.echo(f"⌛️ Downloading and saving {fname}...", nl=False)
+                    nb_data = await nb.get_contents(fname)
+                    nb = nbformat.from_dict(nb_data)
+                    output_fname = os.path.join(output_dir, fname) if output_dir else fname
+                    with open(output_fname, 'w', encoding='utf-8') as f:
+                        nbformat.write(nb, f)
+                    click.echo("✅")
+                except Exception as e:
+                    errors[fname] = e
+                    click.echo(f'❌ error running {fname}: {e}')
 
         if len(errors) > 0:
             raise RuntimeError(str(errors))

--- a/binderbot/cli.py
+++ b/binderbot/cli.py
@@ -7,7 +7,8 @@ import sys
 import click
 import nbformat
 
-from .binderbot import BinderUser, NotebookClient
+from .binderbot import BinderUser
+from .notebookclient import NotebookClient
 
 # https://github.com/pallets/click/issues/85#issuecomment-43378930
 def coro(f):

--- a/binderbot/kernel.py
+++ b/binderbot/kernel.py
@@ -1,0 +1,161 @@
+from . import OperationError
+import uuid
+import time
+import aiohttp
+import textwrap
+import re
+
+# https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+def _ansi_escape(text):
+    return re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])').sub('', text)
+
+class Kernel:
+    """
+    Represents a running jupyter kernel
+    """
+
+    def __init__(self, nbclient, kernel_id: str):
+        self.nbclient = nbclient
+        self.kernel_id = kernel_id
+        self.log = nbclient.log
+
+    def request_execute_code(self, msg_id, code):
+        return {
+            "header": {
+                "msg_id": msg_id,
+                "username": "jovyan",
+                "msg_type": "execute_request",
+                "version": "5.2"
+            },
+            "metadata": {},
+            "content": {
+                "code": textwrap.dedent(code),
+                "silent": False,
+                "store_history": True,
+                "user_expressions": {},
+                "allow_stdin": True,
+                "stop_on_error": True
+            },
+            "buffers": [],
+            "parent_header": {},
+            "channel": "shell"
+        }
+
+    async def run_code(self, code):
+        """Run code and return stdout, stderr."""
+        channel_url = self.nbclient.url / 'api/kernels' / self.kernel_id / 'channels'
+        self.log.msg('WS: Connecting', action='kernel-connect', phase='start')
+        is_connected = False
+        try:
+            async with self.nbclient.session.ws_connect(channel_url) as ws:
+                is_connected = True
+                self.log.msg('WS: Connected', action='kernel-connect', phase='complete')
+                start_time = time.monotonic()
+                self.log.msg('Code Execute: Started', action='code-execute', phase='start')
+                exec_start_time = time.monotonic()
+                msg_id = str(uuid.uuid4())
+                await ws.send_json(self.request_execute_code(msg_id, code))
+
+                stdout = ''
+                stderr = ''
+
+                async for msg_text in ws:
+                    if msg_text.type != aiohttp.WSMsgType.TEXT:
+                        self.log.msg(
+                            'WS: Unexpected message type',
+                            action='code-execute', phase='failure',
+                            message_type=msg_text.type, message=str(msg_text),
+                            duration=time.monotonic() - exec_start_time
+                        )
+                        raise OperationError()
+
+                    msg = msg_text.json()
+
+                    if 'parent_header' in msg and msg['parent_header'].get('msg_id') == msg_id:
+                        # These are responses to our request
+                        self.log.msg(f'Code Execute: Receive response', action='code-execute', phase='receive-stream',
+                                     channel=msg['channel'], msg_type=msg['msg_type'])
+                        if msg['channel'] == 'shell':
+                            if msg['msg_type'] == 'execute_reply':
+                                status = msg['content']['status']
+                                if status == 'ok':
+                                    self.log.msg('Code Execute: Status OK', action='code-execute', phase='success')
+                                    break
+                                else:
+                                    self.log.msg('Code Execute: Status {status}', action='code-execute', phase='error')
+                                    raise OperationError()
+                        if msg['channel'] == 'iopub':
+                            response = None
+                            msg_type = msg.get('msg_type')
+                            # don't really know what this is doing
+                            #if msg_type == 'execute_result':
+                            #    response = msg['content']['data']['text/plain']
+                            if msg_type == 'error':
+                                traceback = _ansi_escape('\n'.join(msg['content']['traceback']))
+                                self.log.msg('Code Execute: Error', action='code-execute',
+                                             phase='error',
+                                             traceback=traceback)
+                                raise OperationError()
+                            elif msg_type == 'stream':
+                                response = msg['content']['text']
+                                name =  msg['content']['name']
+                                if name == 'stdout':
+                                    stdout += response
+                                elif name == 'stderr':
+                                    stderr += response
+                                #print(response)
+                self.log.msg(
+                    'Code Execute: complete',
+                    action='code-execute', phase='complete',
+                    duration=time.monotonic() - exec_start_time)
+
+                return stdout, stderr
+
+        except Exception as e:
+            if type(e) is OperationError:
+                raise
+            if is_connected:
+                self.log.msg('Code Execute: Failed {}'.format(str(e)), action='code-execute', phase='failure')
+            else:
+                self.log.msg('WS: Failed {}'.format(str(e)), action='kernel-connect', phase='failure')
+            raise OperationError()
+
+
+
+    async def execute_notebook(self, notebook_filename, timeout=600,
+                               env_vars={}):
+        env_var_str = str(env_vars)
+        # https://nbconvert.readthedocs.io/en/latest/execute_api.html
+        code = f"""
+        import os
+        import nbformat
+        os.environ.update({env_var_str})
+        from nbconvert.preprocessors import ExecutePreprocessor
+        ep = ExecutePreprocessor(timeout={timeout})
+        print("Processing {notebook_filename}")
+        with open("{notebook_filename}") as f:
+            nb = nbformat.read(f, as_version=4)
+        ep.preprocess(nb, dict())
+        print("OK")
+        print("Saving {notebook_filename}")
+        with open("{notebook_filename}", 'w', encoding='utf-8') as f:
+            nbformat.write(nb, f)
+        print("OK")
+        """
+        return await self.run_code(code)
+
+
+    async def stop_kernel(self):
+        self.log.msg('Kernel: Stopping', action='kernel-stop', phase='start')
+        start_time = time.monotonic()
+        try:
+            resp = await self.nbclient.session.delete(self.nbclient.url / 'api/kernels' / self.kernel_id, headers=self.nbclient.auth_headers)
+        except Exception as e:
+            self.log.msg('Kernel:Failed Stopped {}'.format(str(e)), action='kernel-stop', phase='failed')
+            raise OperationError()
+
+        if resp.status != 204:
+            self.log.msg('Kernel:Failed Stopped {}'.format(str(resp)), action='kernel-stop', phase='failed')
+            raise OperationError()
+
+        self.log.msg('Kernel: Stopped', action='kernel-stop', phase='complete')

--- a/binderbot/notebookclient.py
+++ b/binderbot/notebookclient.py
@@ -1,0 +1,95 @@
+"""Main module.
+
+Much of this code was adopted from Hubtraf, by Yuvi Panda:
+https://github.com/yuvipanda/hubtraf/blob/master/hubtraf/user.py
+"""
+
+import aiohttp
+import random
+from yarl import URL
+import structlog
+import time
+import json
+from contextlib import asynccontextmanager
+
+import nbformat
+from nbconvert.preprocessors import ClearOutputPreprocessor
+
+from binderbot import OperationError
+from .kernel import Kernel
+
+logger = structlog.get_logger()
+
+
+class NotebookClient:
+    """
+    Client for doing operations against a notebook server
+    """
+    def __init__(self, session: aiohttp.ClientSession, url: URL, token: str, log: structlog.BoundLogger):
+        # FIXME: If we get this from BinderBot, will it close properly?
+        self.session = session
+        self.url = url
+        self.token = token
+        self.log = log
+
+        self.auth_headers = {
+            'Authorization': f'token {self.token}'
+        }
+
+    @asynccontextmanager
+    async def start_kernel(self, cleanup=True):
+        self.log.msg('Kernel: Starting', action='kernel-start', phase='start')
+        start_time = time.monotonic()
+
+        try:
+            resp = await self.session.post(self.url / 'api/kernels', headers=self.auth_headers)
+        except Exception as e:
+            self.log.msg('Kernel: Start failed {}'.format(str(e)), action='kernel-start', phase='failed', duration=time.monotonic() - start_time)
+            raise OperationError()
+
+        if resp.status != 201:
+            self.log.msg('Kernel: Start failed', action='kernel-start', phase='failed')
+            raise OperationError()
+        kernel_id = (await resp.json())['id']
+        self.log.msg('Kernel: Started', action='kernel-start', phase='complete')
+        k = Kernel(self, kernel_id)
+        try:
+            yield k
+        finally:
+            if cleanup:
+                await k.stop_kernel()
+
+    # https://github.com/jupyter/jupyter/wiki/Jupyter-Notebook-Server-API#notebook-and-file-contents-api
+    async def get_contents(self, path):
+        resp = await self.session.get(self.url / 'api/contents' / path, headers=self.auth_headers)
+        resp_json = await resp.json()
+        return resp_json['content']
+
+    async def put_contents(self, path, nb_data):
+        data = {'content': nb_data, "type": "notebook"}
+        resp = await self.session.put(self.url / 'api/contents' / path,
+                                      json=data, headers=self.auth_headers)
+        resp.raise_for_status()
+
+
+    async def list_notebooks(self):
+        code = """
+        import os, fnmatch, json
+        notebooks = [f for f in os.listdir() if fnmatch.fnmatch(f, '*.ipynb')]
+        print(json.dumps(notebooks))
+        """
+        stdout, stderr = await self.run_code(code)
+        return json.loads(stdout)
+
+    async def upload_local_notebook(self, notebook_filename):
+        nb = open_nb_and_strip_output(notebook_filename)
+        # probably want to use basename instead
+        await self.put_contents(notebook_filename, nb)
+
+
+def open_nb_and_strip_output(fname):
+    cop = ClearOutputPreprocessor()
+    with open(fname) as f:
+        nb = nbformat.read(f, as_version=4)
+    cop.preprocess(nb, dict())
+    return nb

--- a/tests/test_binderbot.py
+++ b/tests/test_binderbot.py
@@ -4,38 +4,96 @@
 
 import os
 
+import typing
+import asyncio
 import pytest
 from click.testing import CliRunner
 import nbformat
+from pathlib import Path
+import subprocess
+import secrets
+from tempfile import TemporaryDirectory
+import socket
+import time
+import yarl
+import structlog
+import aiohttp
 
 from binderbot import binderbot
 from binderbot import cli
 
+class LocalNotebookServer:
+    def __init__(self, url: yarl.URL, token: str, cwd: Path):
+        self.url = url
+        self.token = token
+        self.cwd = cwd
 
-@pytest.fixture()
-def example_nb_data():
-    nbdata = {'cells': [{'cell_type': 'code',
-                       'execution_count': None,
-                       'metadata': {},
-                       'outputs': [],
-                       'source': 'import socket\nprint(socket.gethostname())'},
-                      {'cell_type': 'code',
-                       'execution_count': None,
-                       'metadata': {},
-                       'outputs': [],
-                       'source': 'import os\nprint(os.environ["MY_VAR"])'}],
-                     'metadata': {'kernelspec': {'display_name': 'Python 3',
-                       'language': 'python',
-                       'name': 'python3'},
-                      'language_info': {'codemirror_mode': {'name': 'ipython', 'version': 3},
-                       'file_extension': '.py',
-                       'mimetype': 'text/x-python',
-                       'name': 'python',
-                       'nbconvert_exporter': 'python',
-                       'pygments_lexer': 'ipython3',
-                       'version': '3.8.1'}},
-                     'nbformat': 4,
-                     'nbformat_minor': 4}
+
+@pytest.fixture
+def free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("0.0.0.0", 0))
+    portnum = s.getsockname()[1]
+    s.close()
+    return portnum
+
+@pytest.fixture
+async def local_notebook(free_port):
+    token = secrets.token_hex(16)
+    with TemporaryDirectory() as tmpdir:
+        #free_port = 8888
+        #token = 'fdbdeca87bd6cf39d366519f5cc0c9c7c994647f6696e8bb'
+        cwd = Path(tmpdir)
+        cmd = [
+            'jupyter', 'notebook',
+            f'--NotebookApp.token={token}',
+            '--port', str(free_port),
+            '--no-browser'
+        ]
+        proc = await asyncio.create_subprocess_exec(*cmd, cwd=tmpdir)
+        # FIXME: Use a http health-check, not a timed wait
+        await asyncio.sleep(2)
+        # localhost is important, aiohttp doesn't really like to authenticate against IPs
+        yield LocalNotebookServer(yarl.URL.build(scheme='http', host='localhost', port=free_port), token=token, cwd=cwd)
+
+        proc.terminate()
+        await proc.wait()
+
+
+def make_code_notebook(cells: typing.List[str]):
+    nbdata = {
+        'cells': [
+            {
+                'cell_type': 'code',
+                'execution_count': None,
+                'metadata': {},
+                'outputs': [],
+                'source': cell
+            } for cell in cells
+        ],
+        'metadata': {
+            'kernelspec': {
+                'display_name': 'Python 3',
+                'language': 'python',
+                'name': 'python3'
+            },
+            'language_info': {
+                'codemirror_mode': {
+                    'name': 'ipython',
+                    'version': 3
+                },
+                'file_extension': '.py',
+                'mimetype': 'text/x-python',
+                'name': 'python',
+                'nbconvert_exporter': 'python',
+                'pygments_lexer': 'ipython3',
+                'version': '3.8.1'
+            }
+        },
+        'nbformat': 4,
+        'nbformat_minor': 4
+    }
     return nbformat.from_dict(nbdata)
 
 
@@ -65,28 +123,44 @@ async def test_binder_start_stop(binder_url):
 
         assert resp.status == 503
 
-def test_cli_upload_execute_download(tmp_path, example_nb_data):
-    """Test the CLI."""
 
-    os.chdir(tmp_path)
-    fname = "example_notebook.ipynb"
-    with open(fname, 'w', encoding='utf-8') as f:
-        nbformat.write(example_nb_data, f)
+@pytest.mark.asyncio
+async def test_nbclient_run_code(local_notebook: LocalNotebookServer):
+    log = structlog.get_logger().bind()
+    async with aiohttp.ClientSession() as session:
+        nbclient = binderbot.NotebookClient(session, local_notebook.url, local_notebook.token, log)
 
-    env = {"MY_VAR": "SECRET"}
-    runner = CliRunner(env=env)
-    args = ["--binder-url", "http://mybinder.org",
-            "--repo", "binder-examples/requirements",
-            "--ref", "master", "--nb-timeout", "10",
-            "--pass-env-var",  "MY_VAR",
-            fname]
-    result = runner.invoke(cli.main, args)
-    assert result.exit_code == 0, result.output
+        await nbclient.start_kernel()
+        stdout, stderr = await nbclient.run_code(f"""
+        print('hi')
+        """)
 
-    with open(fname) as f:
-        nb = nbformat.read(f, as_version=4)
+        assert stderr.strip() == ""
+        assert stdout.strip() == 'hi'
 
-    hostname = nb['cells'][0]['outputs'][0]['text']
-    assert hostname.startswith('jupyter-binder-')
-    remote_env_var_value = nb['cells'][1]['outputs'][0]['text']
-    assert remote_env_var_value.rstrip() == env['MY_VAR']
+        await nbclient.stop_kernel()
+
+@pytest.mark.asyncio
+async def test_upload(local_notebook: LocalNotebookServer):
+    log = structlog.get_logger().bind()
+    async with aiohttp.ClientSession() as session:
+        nbclient = binderbot.NotebookClient(session, local_notebook.url, local_notebook.token, log)
+
+        await nbclient.start_kernel()
+        fname = "example-notebook.ipynb"
+        filepath = local_notebook.cwd / fname
+        input_notebook = make_code_notebook(["print('hello')"])
+        with open(filepath, 'w', encoding='utf-8') as f:
+            nbformat.write(input_notebook, f)
+
+        await nbclient.execute_notebook(
+            fname,
+            timeout=60,
+            )
+        nb_data = await nbclient.get_contents(fname)
+        nb = nbformat.from_dict(nb_data)
+
+        cell1 = nb['cells'][0]['outputs'][0]['text']
+        assert cell1 == "hello\n"
+
+        await nbclient.stop_kernel()


### PR DESCRIPTION
This PR refactors most of the code into three classes:

1. BinderUser, responsible for starting and stopping binders
2. NotebookClient, a standalone client for the Jupyter Notebook
   REST API
3. Kernel, a representation of a single active kernel in a
   Jupyter Notebook server.

This has many advantages:

1. Much easier unit testing, since everything is separated out
2. We can run unit tests for `NotebookClient` and `Kernel` against
   a local ephemeral instance of Notebook Server, making it much
   faster.
3. You can run multiple kernels for code off the same notebook
   server, matching what the REST API does.

This PR adds unit tests, and implements functionality to shut
down binders when we are done with them (#3). We also remove
the state enum asserts in the code - they were a sanity-check
mechanism in hubtraf, and error handling should be implemented
differently here.